### PR TITLE
Add Dockerfile for GCP deployment

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -142,6 +142,7 @@ langchain.readthedocs.io/
 bin/
 pyvenv.cfg
 node_modules/
+.next/
 .envrc
 
 .yarn/*

--- a/README.md
+++ b/README.md
@@ -43,3 +43,22 @@ Looking to use or modify this Use Case Accelerant for your own needs? We've adde
 - **[LangSmith](./LANGSMITH.md)**: A guide on adding robustness to your application using LangSmith. Covers observability, evaluations, and feedback.
 - **[Production](./PRODUCTION.md)**: Documentation on preparing your application for production usage. Explains different security considerations, and more.
 - **[Deployment](./DEPLOYMENT.md)**: How to deploy your application to production. Covers setting up production databases, deploying the frontend, and more.
+
+## Deploying the frontend to GCP
+
+While the recommended hosting provider is Vercel, you can also run the Next.js
+frontend on Google Cloud Run. A `Dockerfile` is available in
+`./frontend` for this purpose. To deploy:
+
+```bash
+cd frontend
+gcloud builds submit --tag gcr.io/<PROJECT_ID>/chat-langchain-frontend
+gcloud run deploy chat-langchain-frontend \
+  --image gcr.io/<PROJECT_ID>/chat-langchain-frontend \
+  --region <REGION> --platform managed --allow-unauthenticated \
+  --set-env-vars NEXT_PUBLIC_API_URL=<backend-url>,API_BASE_URL=<backend-url>,LANGCHAIN_API_KEY=<langsmith-key>
+```
+
+Replace the placeholders with your own project information and environment
+variables. After deployment completes, Cloud Run will provide a public URL for
+your app.

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,25 @@
+# Use official Node.js runtime as a parent image
+FROM node:18
+
+# Set the working directory
+WORKDIR /app
+
+# Copy package files and install dependencies
+COPY package.json yarn.lock ./
+RUN yarn install --frozen-lockfile
+
+# Set environment to production
+ENV NODE_ENV=production
+
+# Copy the rest of the application code
+COPY . .
+
+# Build the Next.js app
+RUN yarn build
+
+# Expose the port used by the app
+ENV PORT=8080
+EXPOSE 8080
+
+# Start the server
+CMD ["yarn", "start", "-p", "8080"]


### PR DESCRIPTION
## Summary
- add Dockerfile to allow running the Next.js frontend in Cloud Run
- ignore `.next` artifacts
- document Cloud Run deployment steps in README

## Testing
- `poetry run ruff check .`
- `poetry run ruff format . --diff` *(fails: 2 files would be reformatted)*