### PR TITLE
Fix LangSmith prompt paths

### DIFF
--- a/backend/retrieval_graph/prompts.py
+++ b/backend/retrieval_graph/prompts.py
@@ -11,32 +11,22 @@ client = Client()
 # )
 
 ROUTER_SYSTEM_PROMPT = (
-    client.pull_prompt("router")
-    .messages[0]
-    .prompt.template
+    client.pull_prompt("margot-na/router").messages[0].prompt.template
 )
 GENERATE_QUERIES_SYSTEM_PROMPT = (
-    client.pull_prompt("langchain-ai/chat-langchain-generate-queries-prompt")
+    client.pull_prompt("margot-na/chat-langchain-generate-queries-prompt")
     .messages[0]
     .prompt.template
 )
 MORE_INFO_SYSTEM_PROMPT = (
-    client.pull_prompt("more_info")
-    .messages[0]
-    .prompt.template
+    client.pull_prompt("margot-na/more_info").messages[0].prompt.template
 )
 RESEARCH_PLAN_SYSTEM_PROMPT = (
-    client.pull_prompt("researcher")
-    .messages[0]
-    .prompt.template
+    client.pull_prompt("margot-na/researcher").messages[0].prompt.template
 )
 GENERAL_SYSTEM_PROMPT = (
-    client.pull_prompt("irrelevant_response")
-    .messages[0]
-    .prompt.template
+    client.pull_prompt("margot-na/irrelevant_response").messages[0].prompt.template
 )
 RESPONSE_SYSTEM_PROMPT = (
-    client.pull_prompt("synthesizer")
-    .messages[0]
-    .prompt.template
+    client.pull_prompt("margot-na/synthesizer").messages[0].prompt.template
 )

--- a/backend/retrieval_graph/test_prompts.py
+++ b/backend/retrieval_graph/test_prompts.py
@@ -3,6 +3,7 @@ from langchain.prompts import load_prompt
 
 client = Client()
 
+
 def list_prompts():
     try:
         prompts = client.list_prompts()
@@ -11,19 +12,21 @@ def list_prompts():
         for prompt in prompts:
             # Format: org_name/prompt_name
             pull_id = f"{prompt}"
-            print(f"client.pull_prompt(\"{pull_id}\")")
+            print(f'client.pull_prompt("{pull_id}")')
     except Exception as e:
         print("Error listing prompts:", str(e))
+
 
 def test_langsmith_connection():
     try:
         # Example using one of your prompts
-        prompt = client.pull_prompt("langchain-ai/chat-langchain-generate-queries-prompt")
+        prompt = client.pull_prompt("margot-na/chat-langchain-generate-queries-prompt")
         print("Successfully connected to LangSmith!")
         print("Prompt content:", prompt.messages[0].prompt.template)
     except Exception as e:
         print("Error connecting to LangSmith:", str(e))
 
+
 if __name__ == "__main__":
-    #list_prompts()
+    # list_prompts()
     test_langsmith_connection()


### PR DESCRIPTION
## Summary
- update retrieval graph to fetch prompts from `margot-na` account
- adjust prompt fetch path in test script

## Testing
- `make format` *(fails: unexpected argument `--select`)*
- `make lint` *(fails: unrecognized subcommand `.`)*

------
https://chatgpt.com/codex/tasks/task_b_683dfb105be8833082f9bce02d40b345