### PR TITLE
Handle trailing path in WEAVIATE_URL

### DIFF
--- a/.env.gcp.yaml.example
+++ b/.env.gcp.yaml.example
@@ -4,6 +4,7 @@ LANGCHAIN_PROJECT: langserve-launch-example
 LANGCHAIN_API_KEY: your_secret_key_here
 FIREWORKS_API_KEY: your_secret_here
 WEAVIATE_API_KEY: your_secret_key_here
+# Do not include trailing paths like `/v1` or a trailing slash
 WEAVIATE_URL: https://your-weaviate-instance.com
 WEAVIATE_INDEX_NAME: your_index_name
 RECORD_MANAGER_DB_URL: your_db_url

--- a/_scripts/clear_index.py
+++ b/_scripts/clear_index.py
@@ -4,13 +4,15 @@ import logging
 import os
 
 import weaviate
+
+from backend.utils import sanitize_weaviate_url
 from langchain.embeddings import OpenAIEmbeddings
 from langchain.indexes import SQLRecordManager, index
 from langchain.vectorstores import Weaviate
 
 logger = logging.getLogger(__name__)
 
-WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
 WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"

--- a/_scripts/evaluate_chains.py
+++ b/_scripts/evaluate_chains.py
@@ -6,6 +6,8 @@ from operator import itemgetter
 from typing import Literal, Optional, Union
 
 import weaviate
+
+from backend.utils import sanitize_weaviate_url
 from langchain import load as langchain_load
 from langchain.chat_models import ChatAnthropic, ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
@@ -109,7 +111,7 @@ def create_chain(
 
 
 def _get_retriever():
-    WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+    WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
     WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 
     client = weaviate.Client(

--- a/_scripts/evaluate_chains_agent.py
+++ b/_scripts/evaluate_chains_agent.py
@@ -4,6 +4,8 @@ import os
 from typing import Optional
 
 import weaviate
+
+from backend.utils import sanitize_weaviate_url
 from langchain import load as langchain_load
 from langchain.agents import AgentExecutor, Tool
 from langchain.agents.openai_functions_agent.agent_token_buffer_memory import (
@@ -20,7 +22,7 @@ from langsmith import Client, RunEvaluator
 from langsmith.evaluation.evaluator import EvaluationResult
 from langsmith.schemas import Example, Run
 
-WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
 

--- a/_scripts/evaluate_chains_improved_chain.py
+++ b/_scripts/evaluate_chains_improved_chain.py
@@ -6,6 +6,8 @@ import os
 from typing import Literal, Optional, Union
 
 import weaviate
+
+from backend.utils import sanitize_weaviate_url
 from langchain import load as langchain_load
 from langchain.chat_models import ChatAnthropic, ChatOpenAI
 from langchain.embeddings import OpenAIEmbeddings
@@ -143,7 +145,7 @@ def create_chain(
 
 
 def _get_retriever():
-    WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+    WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
     WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 
     client = weaviate.Client(

--- a/backend/ingest.py
+++ b/backend/ingest.py
@@ -18,6 +18,7 @@ from langchain_weaviate import WeaviateVectorStore
 from backend.constants import WEAVIATE_DOCS_INDEX_NAME
 from backend.embeddings import get_embeddings_model
 from backend.parser import langchain_docs_extractor
+from backend.utils import sanitize_weaviate_url
 
 
 from langchain.schema import Document
@@ -32,18 +33,18 @@ logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
 # Choose a directory that is in the search path, or add your own
-nltk_data_dir = os.path.expanduser('~/nltk_data')
+nltk_data_dir = os.path.expanduser("~/nltk_data")
 if nltk_data_dir not in nltk.data.path:
     nltk.data.path.append(nltk_data_dir)
 
 # Download to that directory
-nltk.download('averaged_perceptron_tagger_eng', download_dir=nltk_data_dir)
-nltk.download('punkt', download_dir=nltk_data_dir)
+nltk.download("averaged_perceptron_tagger_eng", download_dir=nltk_data_dir)
+nltk.download("punkt", download_dir=nltk_data_dir)
 
 print("NLTK data path:", nltk.data.path)
 
 try:
-    nltk.data.find('taggers/averaged_perceptron_tagger_eng')
+    nltk.data.find("taggers/averaged_perceptron_tagger_eng")
     print("averaged_perceptron_tagger_eng found!")
 except LookupError:
     print("averaged_perceptron_tagger_eng NOT found!")
@@ -151,7 +152,7 @@ def load_methodology_docs(
         root,
         glob="**/*[!~$]*.docx",  # exclude files starting with ~$
         loader_cls=UnstructuredWordDocumentLoader,
-        loader_kwargs={"mode": "single"}
+        loader_kwargs={"mode": "single"},
     )
     docs = dir_loader.load()  # synchronous
 
@@ -209,7 +210,7 @@ def load_api_docs():
 
 
 def ingest_docs():
-    WEAVIATE_URL = os.environ["WEAVIATE_URL"]
+    WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
     WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
     RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
 

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -10,6 +10,7 @@ from langchain_weaviate import WeaviateVectorStore
 
 from backend.configuration import BaseConfiguration
 from backend.constants import WEAVIATE_DOCS_INDEX_NAME
+from backend.utils import sanitize_weaviate_url
 
 
 def make_text_encoder(model: str) -> Embeddings:
@@ -28,8 +29,10 @@ def make_text_encoder(model: str) -> Embeddings:
 def make_weaviate_retriever(
     configuration: BaseConfiguration, embedding_model: Embeddings
 ) -> Iterator[BaseRetriever]:
+    cluster_url = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
+
     with weaviate.connect_to_weaviate_cloud(
-        cluster_url=os.environ["WEAVIATE_URL"],
+        cluster_url=cluster_url,
         auth_credentials=weaviate.classes.init.Auth.api_key(
             os.environ.get("WEAVIATE_API_KEY", "not_provided")
         ),

--- a/backend/utils.py
+++ b/backend/utils.py
@@ -144,3 +144,12 @@ def reduce_docs(
                     existing_ids.add(item_id)
 
     return existing_list + new_list
+
+
+def sanitize_weaviate_url(url: str) -> str:
+    """Remove trailing paths like '/v1' from a Weaviate cluster URL."""
+
+    cleaned = url.rstrip("/")
+    if cleaned.endswith("/v1"):
+        cleaned = cleaned[: -len("/v1")]
+    return cleaned


### PR DESCRIPTION
## Summary
- sanitize `WEAVIATE_URL` when creating Weaviate clients
- use helper to clean URL across scripts
- document to avoid `/v1` or trailing slash in example env file

## Testing
- `make format` *(fails: unexpected argument)*
- `make lint` *(fails: unrecognized subcommand)*
- `python -m py_compile backend/utils.py backend/retrieval.py backend/ingest.py _scripts/clear_index.py _scripts/evaluate_chains.py _scripts/evaluate_chains_improved_chain.py _scripts/evaluate_chains_agent.py`

------
https://chatgpt.com/codex/tasks/task_b_683eec634af0833087516cd2349229d9