### PR TITLE
Allow env var for index name

### DIFF
--- a/.env.gcp.yaml.example
+++ b/.env.gcp.yaml.example
@@ -6,5 +6,5 @@ FIREWORKS_API_KEY: your_secret_here
 WEAVIATE_API_KEY: your_secret_key_here
 # Do not include trailing paths like `/v1` or a trailing slash
 WEAVIATE_URL: https://your-weaviate-instance.com
-WEAVIATE_INDEX_NAME: your_index_name
+WEAVIATE_INDEX_NAME: naturealpha-methdology
 RECORD_MANAGER_DB_URL: your_db_url

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -16,7 +16,9 @@ Once your cluster has been created you should see a few sections on the page. Th
 
 Next, click "API Keys" and save the API key in the environment variable `WEAVIATE_API_KEY`.
 
-The final Weaviate environment variable is "WEAVIATE_INDEX_NAME". This is the name of the index you want to use. You can name it whatever you want, but for this example, we'll use "langchain".
+The final Weaviate environment variable is ``WEAVIATE_INDEX_NAME``. This is the
+name of the index you want to use. You can name it whatever you want, but for
+the NatureAlpha deployment we will use ``naturealpha-methdology``.
 
 After this your vector store will be setup. We can now move onto the record manager.
 
@@ -66,7 +68,7 @@ When configuring, click "Add secret" and add the following secrets:
 OPENAI_API_KEY=
 RECORD_MANAGER_DB_URL=
 WEAVIATE_API_KEY=
-WEAVIATE_INDEX_NAME=langchain
+WEAVIATE_INDEX_NAME=naturealpha-methdology
 WEAVIATE_URL=
 ```
 

--- a/_scripts/clear_index.py
+++ b/_scripts/clear_index.py
@@ -15,7 +15,9 @@ logger = logging.getLogger(__name__)
 WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
-WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
+    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+)
 
 
 def clear():

--- a/_scripts/evaluate_chains.py
+++ b/_scripts/evaluate_chains.py
@@ -30,7 +30,9 @@ _MODEL_MAP = {
     "openai": "gpt-3.5-turbo-1106",
     "anthropic": "claude-2",
 }
-WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
+    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+)
 
 
 def create_chain(

--- a/_scripts/evaluate_chains_agent.py
+++ b/_scripts/evaluate_chains_agent.py
@@ -24,7 +24,9 @@ from langsmith.schemas import Example, Run
 
 WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
-WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
+    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+)
 
 
 def search(inp: str, callbacks=None) -> list:

--- a/_scripts/evaluate_chains_improved_chain.py
+++ b/_scripts/evaluate_chains_improved_chain.py
@@ -31,7 +31,9 @@ _MODEL_MAP = {
     "openai": "gpt-3.5-turbo-1106",
     "anthropic": "claude-2",
 }
-WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
+    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+)
 
 
 def search(search_queries, retriever: BaseRetriever):

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -1,1 +1,10 @@
-WEAVIATE_DOCS_INDEX_NAME = "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+"""Constants used throughout the backend package."""
+
+import os
+
+# Allow overriding the default index name via the ``WEAVIATE_INDEX_NAME``
+# environment variable so deployments can configure their own index without
+# modifying the code.
+WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
+    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
+)


### PR DESCRIPTION
## Summary
- allow overriding the Weaviate index name via `WEAVIATE_INDEX_NAME`
- document new index name `naturealpha-methdology`
- update helper scripts to read index name from the environment

## Testing
- `make format` *(fails: unexpected argument '--select')*
- `make lint` *(fails: unrecognized subcommand '.')*
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langsmith')*

------
https://chatgpt.com/codex/tasks/task_b_68401d1fb1c08330ac56e0645c1c58e1