### PR TITLE
Fix env var detection and log vector store

### DIFF
--- a/.env.gcp.yaml.example
+++ b/.env.gcp.yaml.example
@@ -6,5 +6,5 @@ FIREWORKS_API_KEY: your_secret_here
 WEAVIATE_API_KEY: your_secret_key_here
 # Do not include trailing paths like `/v1` or a trailing slash
 WEAVIATE_URL: https://your-weaviate-instance.com
-WEAVIATE_INDEX_NAME: naturealpha-methdology
+WEAVIATE_INDEX_NAME: naturealpha-methodology
 RECORD_MANAGER_DB_URL: your_db_url

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -18,7 +18,7 @@ Next, click "API Keys" and save the API key in the environment variable `WEAVIAT
 
 The final Weaviate environment variable is ``WEAVIATE_INDEX_NAME``. This is the
 name of the index you want to use. You can name it whatever you want, but for
-the NatureAlpha deployment we will use ``naturealpha-methdology``.
+the NatureAlpha deployment we will use ``naturealpha-methodology``.
 
 After this your vector store will be setup. We can now move onto the record manager.
 
@@ -68,7 +68,7 @@ When configuring, click "Add secret" and add the following secrets:
 OPENAI_API_KEY=
 RECORD_MANAGER_DB_URL=
 WEAVIATE_API_KEY=
-WEAVIATE_INDEX_NAME=naturealpha-methdology
+WEAVIATE_INDEX_NAME=naturealpha-methodology
 WEAVIATE_URL=
 ```
 

--- a/_scripts/clear_index.py
+++ b/_scripts/clear_index.py
@@ -15,9 +15,7 @@ logger = logging.getLogger(__name__)
 WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
 RECORD_MANAGER_DB_URL = os.environ["RECORD_MANAGER_DB_URL"]
-WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
-    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
-)
+WEAVIATE_DOCS_INDEX_NAME = os.environ["WEAVIATE_INDEX_NAME"]
 
 
 def clear():

--- a/_scripts/evaluate_chains.py
+++ b/_scripts/evaluate_chains.py
@@ -30,9 +30,7 @@ _MODEL_MAP = {
     "openai": "gpt-3.5-turbo-1106",
     "anthropic": "claude-2",
 }
-WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
-    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
-)
+WEAVIATE_DOCS_INDEX_NAME = os.environ["WEAVIATE_INDEX_NAME"]
 
 
 def create_chain(

--- a/_scripts/evaluate_chains_agent.py
+++ b/_scripts/evaluate_chains_agent.py
@@ -24,9 +24,7 @@ from langsmith.schemas import Example, Run
 
 WEAVIATE_URL = sanitize_weaviate_url(os.environ["WEAVIATE_URL"])
 WEAVIATE_API_KEY = os.environ["WEAVIATE_API_KEY"]
-WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
-    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
-)
+WEAVIATE_DOCS_INDEX_NAME = os.environ["WEAVIATE_INDEX_NAME"]
 
 
 def search(inp: str, callbacks=None) -> list:

--- a/_scripts/evaluate_chains_improved_chain.py
+++ b/_scripts/evaluate_chains_improved_chain.py
@@ -31,9 +31,7 @@ _MODEL_MAP = {
     "openai": "gpt-3.5-turbo-1106",
     "anthropic": "claude-2",
 }
-WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
-    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
-)
+WEAVIATE_DOCS_INDEX_NAME = os.environ["WEAVIATE_INDEX_NAME"]
 
 
 def search(search_queries, retriever: BaseRetriever):

--- a/backend/constants.py
+++ b/backend/constants.py
@@ -2,9 +2,11 @@
 
 import os
 
-# Allow overriding the default index name via the ``WEAVIATE_INDEX_NAME``
-# environment variable so deployments can configure their own index without
-# modifying the code.
-WEAVIATE_DOCS_INDEX_NAME = os.environ.get(
-    "WEAVIATE_INDEX_NAME", "LangChain_Combined_Docs_OpenAI_text_embedding_3_small"
-)
+# The ``WEAVIATE_INDEX_NAME`` environment variable must be set so that
+# deployments explicitly control which Weaviate index is used.  Falling back
+# to a default value can easily lead to the wrong data being queried, so we
+# raise an error if the variable is missing.
+try:
+    WEAVIATE_DOCS_INDEX_NAME = os.environ["WEAVIATE_INDEX_NAME"]
+except KeyError as exc:
+    raise RuntimeError("WEAVIATE_INDEX_NAME environment variable must be set") from exc

--- a/backend/retrieval.py
+++ b/backend/retrieval.py
@@ -38,6 +38,10 @@ def make_weaviate_retriever(
         ),
         skip_init_checks=True,
     ) as weaviate_client:
+        print(
+            f"Using Weaviate index '{WEAVIATE_DOCS_INDEX_NAME}' at {cluster_url}",
+            flush=True,
+        )
         store = WeaviateVectorStore(
             client=weaviate_client,
             index_name=WEAVIATE_DOCS_INDEX_NAME,


### PR DESCRIPTION
## Summary
- require `WEAVIATE_INDEX_NAME` env var instead of falling back to a default
- log the Weaviate index being used when retrieving documents
- update helper scripts to rely on `WEAVIATE_INDEX_NAME`

## Testing
- `poetry run ruff check .` *(fails: unused imports in unrelated files)*
- `poetry run pytest` *(fails: ModuleNotFoundError: No module named 'langsmith', ModuleNotFoundError: No module named 'pandas')*

------
https://chatgpt.com/codex/tasks/task_b_684aa76f17088330971222930a26a106