### PR TITLE
Fix generate prompt reference

### DIFF
--- a/backend/retrieval_graph/test_prompts.py
+++ b/backend/retrieval_graph/test_prompts.py
@@ -21,7 +21,7 @@ def test_langsmith_connection():
     try:
         # Example using one of your prompts
         prompt = client.pull_prompt(
-            "margot-na/generate-queries"
+            "langchain-ai/chat-langchain-generate-queries-prompt"
         )
 
         print("Successfully connected to LangSmith!")


### PR DESCRIPTION
## Summary
- point `test_langsmith_connection` to the updated `generate-queries` prompt id

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'langsmith')*

------
https://chatgpt.com/codex/tasks/task_b_6852e5f22d908330bace108f13f75631